### PR TITLE
Add RabbitMQ integration

### DIFF
--- a/Microservices/ControllerFirst/ControllerFirst.csproj
+++ b/Microservices/ControllerFirst/ControllerFirst.csproj
@@ -30,6 +30,7 @@
         <PackageReference Include="NewtonSoft.Json" Version="13.0.3" />
         <PackageReference Include="Scalar.AspNetCore" Version="2.0.12" />
         <PackageReference Include="SharpGrip.FluentValidation.AutoValidation.Mvc" Version="1.5.0" />
+        <PackageReference Include="RabbitMQ.Client" Version="6.8.0" />
         <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="8.4.0" />
     </ItemGroup>
 

--- a/Microservices/ControllerFirst/Services/Classes/RabbitMqListener.cs
+++ b/Microservices/ControllerFirst/Services/Classes/RabbitMqListener.cs
@@ -1,0 +1,57 @@
+using System.Text;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Hosting;
+using RabbitMQ.Client;
+using RabbitMQ.Client.Events;
+
+namespace ControllerFirst.Services.Classes;
+
+public class RabbitMqListener : BackgroundService
+{
+    private readonly IConfiguration _configuration;
+    private IConnection? _connection;
+    private IModel? _channel;
+    private string _queue = "weather";
+
+    public RabbitMqListener(IConfiguration configuration)
+    {
+        _configuration = configuration;
+    }
+
+    protected override Task ExecuteAsync(CancellationToken stoppingToken)
+    {
+        var factory = new ConnectionFactory
+        {
+            HostName = _configuration["RabbitMQ:Host"] ?? "rabbitmq",
+            UserName = _configuration["RabbitMQ:Username"],
+            Password = _configuration["RabbitMQ:Password"]
+        };
+        _queue = _configuration["RabbitMQ:Queue"] ?? "weather";
+        _connection = factory.CreateConnection();
+        _channel = _connection.CreateModel();
+        _channel.QueueDeclare(queue: _queue,
+                             durable: false,
+                             exclusive: false,
+                             autoDelete: false,
+                             arguments: null);
+
+        var consumer = new EventingBasicConsumer(_channel);
+        consumer.Received += (ch, ea) =>
+        {
+            var body = ea.Body.ToArray();
+            var message = Encoding.UTF8.GetString(body);
+            Console.WriteLine($"RabbitMQ message: {message}");
+            _channel.BasicAck(ea.DeliveryTag, false);
+        };
+
+        _channel.BasicConsume(queue: _queue, autoAck: false, consumer: consumer);
+        return Task.CompletedTask;
+    }
+
+    public override void Dispose()
+    {
+        _channel?.Close();
+        _connection?.Close();
+        base.Dispose();
+    }
+}

--- a/Microservices/ControllerFirst/Startup.cs
+++ b/Microservices/ControllerFirst/Startup.cs
@@ -147,6 +147,8 @@ public class Startup
             return new ElasticClient(settings);
         });
 
+        services.AddHostedService<RabbitMqListener>();
+
     }
 
     public void Configure(WebApplication app)

--- a/Microservices/ControllerFirst/appsettings.Development.json
+++ b/Microservices/ControllerFirst/appsettings.Development.json
@@ -4,5 +4,11 @@
       "Default": "Information",
       "Microsoft.AspNetCore": "Warning"
     }
+  },
+  "RabbitMQ": {
+    "Host": "rabbitmq",
+    "Username": "guest",
+    "Password": "guest",
+    "Queue": "weather"
   }
 }

--- a/Microservices/WeatherApp/Program.cs
+++ b/Microservices/WeatherApp/Program.cs
@@ -1,11 +1,13 @@
 using System.Text;
 using Microsoft.AspNetCore.Authentication.JwtBearer;
 using Microsoft.IdentityModel.Tokens;
+using WeatherApp;
 
 var builder = WebApplication.CreateBuilder(args);
 
 builder.Services.AddOpenApi();
 builder.Services.AddControllers();
+builder.Services.AddSingleton<RabbitMqService>();
 
 builder.WebHost.ConfigureKestrel(ops =>
 {

--- a/Microservices/WeatherApp/RabbitMqService.cs
+++ b/Microservices/WeatherApp/RabbitMqService.cs
@@ -1,0 +1,46 @@
+using System.Text;
+using Microsoft.Extensions.Configuration;
+using RabbitMQ.Client;
+
+namespace WeatherApp;
+
+public class RabbitMqService : IDisposable
+{
+    private readonly IModel _channel;
+    private readonly IConnection _connection;
+    private readonly string _queue;
+
+    public RabbitMqService(IConfiguration configuration)
+    {
+        var factory = new ConnectionFactory
+        {
+            HostName = configuration["RabbitMQ:Host"] ?? "rabbitmq",
+            UserName = configuration["RabbitMQ:Username"],
+            Password = configuration["RabbitMQ:Password"]
+        };
+        _queue = configuration["RabbitMQ:Queue"] ?? "weather";
+
+        _connection = factory.CreateConnection();
+        _channel = _connection.CreateModel();
+        _channel.QueueDeclare(queue: _queue,
+                             durable: false,
+                             exclusive: false,
+                             autoDelete: false,
+                             arguments: null);
+    }
+
+    public void Publish(string message)
+    {
+        var body = Encoding.UTF8.GetBytes(message);
+        _channel.BasicPublish(exchange: string.Empty,
+                             routingKey: _queue,
+                             basicProperties: null,
+                             body: body);
+    }
+
+    public void Dispose()
+    {
+        if (_channel.IsOpen) _channel.Close();
+        _connection.Close();
+    }
+}

--- a/Microservices/WeatherApp/WeatherApp.csproj
+++ b/Microservices/WeatherApp/WeatherApp.csproj
@@ -10,6 +10,7 @@
     <ItemGroup>
         <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="9.0.5" />
         <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="9.0.4"/>
+        <PackageReference Include="RabbitMQ.Client" Version="6.8.0" />
     </ItemGroup>
 
 </Project>

--- a/Microservices/WeatherApp/WeatherController.cs
+++ b/Microservices/WeatherApp/WeatherController.cs
@@ -1,5 +1,6 @@
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
+using System.Text.Json;
 
 namespace WeatherApp;
 
@@ -7,6 +8,13 @@ namespace WeatherApp;
 [Route("api/[controller]")]
 public class WeatherController : ControllerBase
 {
+    private readonly RabbitMqService _rabbit;
+
+    public WeatherController(RabbitMqService rabbit)
+    {
+        _rabbit = rabbit;
+    }
+
     [Authorize(Policy = "UserPolicy")]
     [HttpGet]
     public IActionResult GetWeather()
@@ -18,6 +26,8 @@ public class WeatherController : ControllerBase
             Location = "New York"
         };
 
+        var json = JsonSerializer.Serialize(weatherData);
+        _rabbit.Publish(json);
         return Ok(weatherData);
     }
     

--- a/Microservices/WeatherApp/appsettings.Development.json
+++ b/Microservices/WeatherApp/appsettings.Development.json
@@ -4,5 +4,11 @@
       "Default": "Information",
       "Microsoft.AspNetCore": "Warning"
     }
+  },
+  "RabbitMQ": {
+    "Host": "rabbitmq",
+    "Username": "guest",
+    "Password": "guest",
+    "Queue": "weather"
   }
 }

--- a/Microservices/deyployments.bash
+++ b/Microservices/deyployments.bash
@@ -9,6 +9,7 @@ kubectl apply -f namespace.yaml
 
 # 2. Загрузить секреты
 kubectl apply -f secrets.yaml
+kubectl apply -f rabbitmq-deployment.yaml
 
 # 3. Деплой ApiGateway
 kubectl apply -f apigateway-deployment.yaml

--- a/Microservices/rabbitmq-deployment.yaml
+++ b/Microservices/rabbitmq-deployment.yaml
@@ -1,0 +1,42 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: rabbitmq
+  namespace: microservices
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: rabbitmq
+  template:
+    metadata:
+      labels:
+        app: rabbitmq
+    spec:
+      containers:
+        - name: rabbitmq
+          image: rabbitmq:3-management
+          ports:
+            - containerPort: 5672
+            - containerPort: 15672
+          env:
+            - name: RABBITMQ_DEFAULT_USER
+              value: guest
+            - name: RABBITMQ_DEFAULT_PASS
+              value: guest
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: rabbitmq
+  namespace: microservices
+spec:
+  selector:
+    app: rabbitmq
+  ports:
+    - name: amqp
+      port: 5672
+      targetPort: 5672
+    - name: management
+      port: 15672
+      targetPort: 15672


### PR DESCRIPTION
## Summary
- add RabbitMqService for WeatherApp
- publish weather info to queue on request
- add RabbitMqListener background service in ControllerFirst
- create RabbitMQ Kubernetes deployment
- deploy RabbitMQ in script
- configure RabbitMQ settings
- reference RabbitMQ.Client packages

## Testing
- `dotnet build Microservices/WeatherApp/WeatherApp.csproj` *(fails: command not found)*
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68402f26ff788332bf54e9eea4713f46